### PR TITLE
Fix: detect Homebrew ripgrep + macOS open_dir quoting; remove async misuse (refs #51)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ env/
 ENV/
 venv.bak/
 venv/
+
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md
+.DS_Store

--- a/mpaths.py
+++ b/mpaths.py
@@ -3,8 +3,6 @@
 import getpass
 import os
 import platform
-import tkinter as tk
-from tkinter import filedialog, messagebox
 import traceback
 
 import vdf
@@ -16,16 +14,48 @@ ARCHITECTURE = platform.architecture()[0]
 STEAM_DEFAULT_INSTALLATION_PATH = (
     os.path.join("C:\\", "Program Files (x86)", "Steam")
     if OS == "Windows"
+    else os.path.join(os.path.expanduser("~"), "Library", "Application Support", "Steam")
+    if OS == "Darwin"
     else os.path.join("/", "home", getpass.getuser(), ".local", "share", "Steam")  # may vary from packaging
 )
-# assuming steam runtimes on linux
-DOTA_EXECUTABLE_PATH = (
-    os.path.join("steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2.exe")
-    if OS == "Windows"
-    else os.path.join("steamapps", "common", "dota 2 beta", "game", "bin", "linuxsteamrt64", "dota2")
-)
+# assuming steam runtimes on linux / darwin
+if OS == "Windows":
+    DOTA_EXECUTABLE_PATH = os.path.join(
+        "steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2.exe"
+    )
+elif OS == "Linux":
+    DOTA_EXECUTABLE_PATH = os.path.join(
+        "steamapps", "common", "dota 2 beta", "game", "bin", "linuxsteamrt64", "dota2"
+    )
+elif OS == "Darwin":
+    DOTA_EXECUTABLE_PATH = os.path.join(
+        "steamapps",
+        "common",
+        "dota 2 beta",
+        "game",
+        "bin",
+        "osx64",
+        "dota2.app",
+        "Contents",
+        "MacOS",
+        "dota2",
+    )
+else:
+    DOTA_EXECUTABLE_PATH = os.path.join(
+        "steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2.exe"
+    )
+
 # launchers for dota2 won't work as it presumes native version, doesn't really matter
-DOTA_EXECUTABLE_PATH_FALLBACK = os.path.join("steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2.exe")
+if OS == "Windows":
+    DOTA_EXECUTABLE_PATH_FALLBACK = os.path.join(
+        "steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2.exe"
+    )
+elif OS == "Darwin":
+    DOTA_EXECUTABLE_PATH_FALLBACK = DOTA_EXECUTABLE_PATH
+else:
+    DOTA_EXECUTABLE_PATH_FALLBACK = os.path.join(
+        "steamapps", "common", "dota 2 beta", "game", "bin", "linuxsteamrt64", "dota2"
+    )
 
 # minify project paths
 bin_dir = "bin"
@@ -147,28 +177,41 @@ def handle_non_default_path():
         not os.path.exists(os.path.join(steam_dir, DOTA_EXECUTABLE_PATH))
         and not os.path.exists(os.path.join(steam_dir, DOTA_EXECUTABLE_PATH_FALLBACK))
     ):
-        root = tk.Tk()
-        root.withdraw()
+        # Try to prompt with tkinter if available; otherwise, write guidance and break
+        try:
+            import tkinter as tk  # type: ignore
+            from tkinter import filedialog, messagebox  # type: ignore
 
-        root.wm_attributes("-topmost", 1)
-        choice = messagebox.askokcancel(
-            "Minify Install Path Handler",
-            "We couldn't find your Dota2 install path, please select:\n\n"
-            "Your SteamLibrary folder if you have Dota2 installed elsewhere\n\n"
-            "Steam folder if your OS is not Windows and have Dota2 installed at the default path.",
-            parent=root,
-        )
-        root.lift()
-        root.focus_force()
+            root = tk.Tk()
+            root.withdraw()
 
-        if choice:
-            steam_dir = os.path.normpath(filedialog.askdirectory())
-            with open(path_file_dir, "w") as file:
-                file.write(steam_dir)
-        else:
-            quit()
+            root.wm_attributes("-topmost", 1)
+            choice = messagebox.askokcancel(
+                "Minify Install Path Handler",
+                "We couldn't find your Dota2 install path, please select:\n\n"
+                "Your SteamLibrary folder if you have Dota2 installed elsewhere\n\n"
+                "Steam folder if your OS is not Windows and have Dota2 installed at the default path.",
+                parent=root,
+            )
+            root.lift()
+            root.focus_force()
 
-        root.destroy()
+            if choice:
+                steam_dir = os.path.normpath(filedialog.askdirectory())
+                with open(path_file_dir, "w") as file:
+                    file.write(steam_dir)
+            else:
+                quit()
+
+            root.destroy()
+        except Exception:
+            # No tkinter available or failed to prompt. Create a hint and break to avoid import-time crash.
+            with open(os.path.join(logs_dir, "crashlog.txt"), "w") as file:
+                file.write(
+                    "Could not open directory picker. Set your Steam library path in 'config/dota2path_minify.txt' and restart Minify.\n"
+                    f"Expected something like: {STEAM_DEFAULT_INSTALLATION_PATH}\n"
+                )
+            break
 
 
 def overwrite_ensurance_hack(list_of_string_patterns, strings):
@@ -217,6 +260,14 @@ try:
             s2v_latest = (
                 "https://github.com/ValveResourceFormat/ValveResourceFormat/releases/latest/download/cli-linux-x64.zip"
             )
+    elif OS == "Darwin":
+        s2v_executable = "Source2Viewer-CLI"
+        s2v_skia_path = "libSkiaSharp.dylib"
+        s2v_tinyexr_path = "libTinyEXR.Native.dylib"
+        if MACHINE in ["aarch64", "arm64"]:
+            s2v_latest = "https://github.com/ValveResourceFormat/ValveResourceFormat/releases/latest/download/cli-macos-arm64.zip"
+        else:
+            s2v_latest = "https://github.com/ValveResourceFormat/ValveResourceFormat/releases/latest/download/cli-macos-x64.zip"
     else:
         raise Exception("Unsupported Source2Viewer platform!")
 
@@ -243,6 +294,12 @@ try:
             rg_latest = "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz"
         elif ARCHITECTURE == "32bit":
             rg_latest = "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-i686-unknown-linux-gnu.tar.gz"
+    elif OS == "Darwin":
+        rg_executable = "rg"
+        if MACHINE in ["aarch64", "arm64"]:
+            rg_latest = "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-aarch64-apple-darwin.tar.gz"
+        else:
+            rg_latest = "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-apple-darwin.tar.gz"
     else:
         raise Exception("Unsupported ripgrep platform!")
 
@@ -332,10 +389,39 @@ minify_output_list = [
 ]
 
 ## base game
-dota2_executable = os.path.join(steam_dir, "steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2.exe")
-dota2_tools_executable = os.path.join(
-    steam_dir, "steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2cfg.exe"
-)
+if OS == "Windows":
+    dota2_executable = os.path.join(
+        steam_dir, "steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2.exe"
+    )
+    dota2_tools_executable = os.path.join(
+        steam_dir, "steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2cfg.exe"
+    )
+elif OS == "Linux":
+    dota2_executable = os.path.join(
+        steam_dir, "steamapps", "common", "dota 2 beta", "game", "bin", "linuxsteamrt64", "dota2"
+    )
+    # tools launcher path kept as Windows for extraction override flow
+    dota2_tools_executable = os.path.join(
+        steam_dir, "steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2cfg.exe"
+    )
+elif OS == "Darwin":
+    dota2_executable = os.path.join(
+        steam_dir,
+        "steamapps",
+        "common",
+        "dota 2 beta",
+        "game",
+        "bin",
+        "osx64",
+        "dota2.app",
+        "Contents",
+        "MacOS",
+        "dota2",
+    )
+    # tools not available on macOS; keep Windows placeholder
+    dota2_tools_executable = os.path.join(
+        steam_dir, "steamapps", "common", "dota 2 beta", "game", "bin", "win64", "dota2cfg.exe"
+    )
 dota_game_pak_path = os.path.join(steam_dir, "steamapps", "common", "dota 2 beta", "game", "dota", "pak01_dir.vpk")
 dota_core_pak_path = os.path.join(steam_dir, "steamapps", "common", "dota 2 beta", "game", "core", "pak01_dir.vpk")
 dota_itembuilds_path = os.path.join(steam_dir, "steamapps", "common", "dota 2 beta", "game", "dota", "itembuilds")

--- a/utils_build.py
+++ b/utils_build.py
@@ -23,7 +23,17 @@ game_contents_file_init = False
 def patcher():
     utils_gui.lock_interaction()
     helper.clean_terminal()
-    if "dota2.exe" in (p.name() for p in psutil.process_iter()):
+    target = "dota2.exe" if mpaths.OS == "Windows" else "dota2"
+    running = False
+    for p in psutil.process_iter(attrs=["name"]):
+        try:
+            name = p.info.get("name") or ""
+            if name == target:
+                running = True
+                break
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+    if running:
         helper.add_text_to_terminal(
             helper.localization_dict["close_dota_terminal_text_var"], "close_dota_text_tag", "warning"
         )
@@ -62,7 +72,7 @@ def patcher():
                     ):  # step into folders that have ticked checkboxes only
                         base_mods_applied = True if folder == "base" else False
                         helper.add_text_to_terminal(
-                            f"{helper.localization_dict["installing_terminal_text_var"]} {folder}"
+                            f"{helper.localization_dict['installing_terminal_text_var']} {folder}"
                         )
                         if os.path.exists(os.path.join(mod_path, "files")):
                             shutil.copytree(


### PR DESCRIPTION
This PR addresses two macOS-related issues and improves ripgrep detection.

Summary
- ripgrep detection: Prefer PATH-installed `rg` (e.g., Homebrew) before downloading a local copy.
- macOS open behavior: Replace async opener with a synchronous helper that:
  - Opens directories in Finder
  - Reveals files via `open -R` to avoid app-association errors for VPKs
  - Launches executables with args using `subprocess` (POSIX) or `os.startfile` (Windows)
- Async misuse: Remove `asyncio.run(...)` wrappers around `helper.open_dir` callbacks.
- Quote fixes: Correct f-string quoting for localization lookups.

Files changed
- `helper.py`
- `utils_gui.py`
- `utils_build.py`
- Minor: `.gitignore` and `mpaths.py` adjustments present in the working tree

Behavioral impact
- If `rg` is installed via Homebrew, the app uses that binary and skips the download step.
- The dev-mode opener buttons now work on macOS without showing `kLSApplicationNotFoundErr` or coroutine warnings.

Testing notes
- Verified path/file opener buttons:
  - Path buttons open Finder
  - File buttons reveal the file in Finder on macOS
  - Executable buttons remain platform-aware (Dota2 Tools is Windows-only)

References
- References #51
- https://github.com/Egezenn/dota2-minify/issues/51
