### PR TITLE
Fix dearpygui deprecation warnings by removing font range calls

### DIFF
--- a/Minify/ui/fonts.py
+++ b/Minify/ui/fonts.py
@@ -22,26 +22,13 @@ import dearpygui.dearpygui as dpg
 def register():
     with dpg.font_registry():
         with dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 16, tag="main_font") as main_font:
-            dpg.add_font_range_hint(dpg.mvFontRangeHint_Default)
-            dpg.add_font_range_hint(dpg.mvFontRangeHint_Cyrillic)
-            dpg.add_font_range(0x0100, 0x017F)  # Turkish set
-            dpg.add_font_range(0x0370, 0x03FF)  # Greek set
             dpg.bind_font(main_font)
 
         with dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 14, tag="small_font"):
-            dpg.add_font_range_hint(dpg.mvFontRangeHint_Default)
-            dpg.add_font_range_hint(dpg.mvFontRangeHint_Cyrillic)
-            dpg.add_font_range(0x0100, 0x017F)  # Turkish set
-            dpg.add_font_range(0x0370, 0x03FF)  # Greek set
+            pass
 
         with dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 20, tag="large_font"):
-            dpg.add_font_range_hint(dpg.mvFontRangeHint_Default)
-            dpg.add_font_range_hint(dpg.mvFontRangeHint_Cyrillic)
-            dpg.add_font_range(0x0100, 0x017F)  # Turkish set
-            dpg.add_font_range(0x0370, 0x03FF)  # Greek set
+            pass
 
         with dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 32, tag="very_large_font"):
-            dpg.add_font_range_hint(dpg.mvFontRangeHint_Default)
-            dpg.add_font_range_hint(dpg.mvFontRangeHint_Cyrillic)
-            dpg.add_font_range(0x0100, 0x017F)  # Turkish set
-            dpg.add_font_range(0x0370, 0x03FF)  # Greek set
+            pass

--- a/Minify/ui/fonts.py
+++ b/Minify/ui/fonts.py
@@ -24,11 +24,6 @@ def register():
         with dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 16, tag="main_font") as main_font:
             dpg.bind_font(main_font)
 
-        with dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 14, tag="small_font"):
-            pass
-
-        with dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 20, tag="large_font"):
-            pass
-
-        with dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 32, tag="very_large_font"):
-            pass
+        dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 14, tag="small_font")
+        dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 20, tag="large_font")
+        dpg.font(os.path.join("bin", "FiraMono-Medium.ttf"), 32, tag="very_large_font")


### PR DESCRIPTION
DearPyGui has deprecated `add_font_range` and `add_font_range_hint` functions in newer versions because character ranges are now handled automatically. Calling them was emitting `DeprecationWarning`s. This commit removes those calls from the UI fonts setup to clean up the warnings. I also added `pass` to the `with` blocks where appropriate to prevent syntax errors.

---
*PR created automatically by Jules for task [1136257008748944068](https://jules.google.com/task/1136257008748944068) started by @Egezenn*