### PR TITLE
Refactor resource compiler call to use helper.compile

### DIFF
--- a/Minify/build.py
+++ b/Minify/build.py
@@ -295,29 +295,7 @@ def patcher(mod=None, pakname=None):
                 ignore=shutil.ignore_patterns("*.vcss_c", "*.vxml_c"),
             )
 
-            # TODO: use helper.compile instead
-            with open(base.log_rescomp, "wb") as file:
-                command = [
-                    constants.dota_resource_compiler_path,
-                    "-i",
-                    constants.minify_dota_compile_input_path + "/*",
-                    "-r",
-                ]
-                if base.OS != base.WIN:
-                    command.insert(0, "wine")
-
-                rescomp = subprocess.run(
-                    command,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,  # compiler complains if minify_dota_compile_input_path is empty
-                    creationflags=subprocess.CREATE_NO_WINDOW if base.OS == base.WIN else 0,
-                )
-                if rescomp.stdout != b"":
-                    file.write(rescomp.stdout)
-
-                # if sp_compiler.stderr != b"":
-                #     decoded_err = sp_compiler.stderr.decode("utf-8")
-                #     raise Exception(decoded_err)
+            helper.compile()
         helper.bulk_exec_script("after_recompile")
 
         if replacer_source_extracts:

--- a/Minify/helper.py
+++ b/Minify/helper.py
@@ -33,6 +33,31 @@ def change_output_path():
     config.set("output_path", output_path)
 
 
+def compile():
+    """
+    A wrapper for the Dota 2 Resource Compiler.
+    """
+    with open(base.log_rescomp, "wb") as file:
+        command = [
+            constants.dota_resource_compiler_path,
+            "-i",
+            constants.minify_dota_compile_input_path + "/*",
+            "-r",
+        ]
+
+        if base.OS != base.WIN:
+            command.insert(0, "wine")
+
+        rescomp = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,  # compiler complains if minify_dota_compile_input_path is empty
+            creationflags=subprocess.CREATE_NO_WINDOW if base.OS == base.WIN else 0,
+        )
+        if rescomp.stdout != b"":
+            file.write(rescomp.stdout)
+
+
 def compile_assets(input_path=None, output_path=None, pak_path=None, sender=None, app_data=None, user_data=None):
     """
     resourcecompiler's friendly cousin
@@ -66,22 +91,7 @@ def compile_assets(input_path=None, output_path=None, pak_path=None, sender=None
             else:
                 shutil.copy(os.path.join(input_path, item), constants.minify_dota_compile_input_path)
 
-        with utils.open_utf8(base.log_rescomp, "w") as file:
-            command = [
-                constants.dota_resource_compiler_path,
-                "-i",
-                constants.minify_dota_compile_input_path + "/*",
-                "-r",
-            ]
-
-            if base.OS != base.WIN:
-                command.insert(0, "wine")
-
-            subprocess.run(
-                command,
-                stdout=file,
-                creationflags=subprocess.CREATE_NO_WINDOW if base.OS == base.WIN else 0,
-            )
+        compile()
 
         fs.create_dirs(constants.minify_dota_compile_output_path)
         shutil.copytree(os.path.join(constants.minify_dota_compile_output_path), output_path)


### PR DESCRIPTION
I have refactored the codebase to use a centralized `helper.compile()` function for asset compilation, as requested.

Key changes:
- Created a new `compile()` function in `Minify/helper.py` that encapsulates the `resourcecompiler.exe` subprocess call, including OS-specific prefixes and appropriate process flags.
- Replaced the inline subprocess call in `Minify/build.py:298` with `helper.compile()`.
- Refactored `helper.compile_assets()` in `Minify/helper.py` to also use the new `compile()` function, ensuring consistency and DRY principles.
- Verified the changes with a custom test script (which was then removed to keep the codebase clean).
- Addressed code review feedback by removing temporary verification files.

---
*PR created automatically by Jules for task [16729415976882904092](https://jules.google.com/task/16729415976882904092) started by @Egezenn*