### PR TITLE
Make modal sizes configurable

### DIFF
--- a/Minify/ui/modal_shared.py
+++ b/Minify/ui/modal_shared.py
@@ -8,9 +8,6 @@ import dearpygui.dearpygui as dpg
 
 modal_queue = []
 
-active_width = 500
-active_height = 300
-
 
 def show(title, messages, buttons, width=500, height=300):
     """
@@ -25,10 +22,6 @@ def show(title, messages, buttons, width=500, height=300):
 
 def show_progress(messages, width=500, height=300):
     """Shows the modal with a progress bar and status text."""
-    global active_width, active_height
-    active_width = width
-    active_height = height
-
     if dpg.does_item_exist("modal_text_wrapper"):
         dpg.delete_item("modal_text_wrapper", children_only=True)
 
@@ -39,7 +32,7 @@ def show_progress(messages, width=500, height=300):
     dpg.configure_item("modal_progress_wrapper", show=True)
     dpg.configure_item("modal_button_wrapper", show=False)
     dpg.configure_item("modal_popup", show=True)
-    configure()
+    configure(width, height)
 
 
 def set_progress(value, status_text=None):
@@ -54,15 +47,11 @@ def show_next_from_queue():
     if not modal_queue:
         return
 
-    global active_width, active_height
     modal_data = modal_queue.pop(0)
     messages = modal_data["messages"]
     buttons = modal_data["buttons"]
     width = modal_data.get("width", 500)
     height = modal_data.get("height", 300)
-
-    active_width = width
-    active_height = height
 
     if dpg.does_item_exist("modal_progress_wrapper"):
         dpg.configure_item("modal_progress_wrapper", show=False)
@@ -103,7 +92,7 @@ def show_next_from_queue():
 
     dpg.configure_item("modal_popup", show=True)
     time.sleep(0.1)
-    configure()
+    configure(width, height)
     time.sleep(0.1)
 
     from ui import window
@@ -112,13 +101,13 @@ def show_next_from_queue():
 
 
 def configure(width=None, height=None):
-    if width is None:
-        width = active_width
-    if height is None:
-        height = active_height
-
     if not dpg.does_item_exist("modal_popup"):
         return
+
+    if width is None:
+        width = dpg.get_item_width("modal_popup") or 500
+    if height is None:
+        height = dpg.get_item_height("modal_popup") or 300
 
     dpg.configure_item(
         "modal_popup",

--- a/Minify/ui/modal_shared.py
+++ b/Minify/ui/modal_shared.py
@@ -8,35 +8,33 @@ import dearpygui.dearpygui as dpg
 
 modal_queue = []
 
-# TODO: sizes should be definable
-MODAL_WIDTH = 500
-MODAL_HEIGHT = 300
-TEXT_WRAPPER_WIDTH = MODAL_WIDTH - 16
-TEXT_WRAPPER_HEIGHT = MODAL_HEIGHT - 80
-TEXT_WRAP = MODAL_WIDTH - 40
+active_width = 500
+active_height = 300
 
 
-def show(title, messages, buttons):
+def show(title, messages, buttons, width=500, height=300):
     """
     Shows a unified modal popup or queues it if one is already active.
     messages: list of strings
     buttons: list of dicts {"label": str, "callback": func, "user_data": any, "width": int}
     """
-    modal_queue.append({"messages": messages, "buttons": buttons})
+    modal_queue.append({"messages": messages, "buttons": buttons, "width": width, "height": height})
     if not dpg.is_item_shown("modal_popup"):
         show_next_from_queue()
 
 
-def show_progress(messages):
+def show_progress(messages, width=500, height=300):
     """Shows the modal with a progress bar and status text."""
+    global active_width, active_height
+    active_width = width
+    active_height = height
+
     if dpg.does_item_exist("modal_text_wrapper"):
         dpg.delete_item("modal_text_wrapper", children_only=True)
 
-    with dpg.child_window(
-        parent="modal_text_wrapper", width=TEXT_WRAPPER_WIDTH, height=TEXT_WRAPPER_HEIGHT / 2, border=False
-    ):
+    with dpg.child_window(parent="modal_text_wrapper", width=width - 16, height=(height - 80) / 2, border=False):
         for msg in messages:
-            dpg.add_text(msg, wrap=TEXT_WRAP)
+            dpg.add_text(msg, wrap=width - 40)
 
     dpg.configure_item("modal_progress_wrapper", show=True)
     dpg.configure_item("modal_button_wrapper", show=False)
@@ -56,9 +54,15 @@ def show_next_from_queue():
     if not modal_queue:
         return
 
+    global active_width, active_height
     modal_data = modal_queue.pop(0)
     messages = modal_data["messages"]
     buttons = modal_data["buttons"]
+    width = modal_data.get("width", 500)
+    height = modal_data.get("height", 300)
+
+    active_width = width
+    active_height = height
 
     if dpg.does_item_exist("modal_progress_wrapper"):
         dpg.configure_item("modal_progress_wrapper", show=False)
@@ -70,11 +74,9 @@ def show_next_from_queue():
 
     dpg.configure_item("modal_button_wrapper", show=True)
 
-    with dpg.child_window(
-        parent="modal_text_wrapper", width=TEXT_WRAPPER_WIDTH, height=TEXT_WRAPPER_HEIGHT, border=False
-    ):
+    with dpg.child_window(parent="modal_text_wrapper", width=width - 16, height=height - 80, border=False):
         for msg in messages:
-            dpg.add_text(msg, wrap=TEXT_WRAP)
+            dpg.add_text(msg, wrap=width - 40)
 
     for btn in buttons:
 
@@ -109,22 +111,27 @@ def show_next_from_queue():
     window.on_resize()
 
 
-def configure():
+def configure(width=None, height=None):
+    if width is None:
+        width = active_width
+    if height is None:
+        height = active_height
+
     if not dpg.does_item_exist("modal_popup"):
         return
 
     dpg.configure_item(
         "modal_popup",
-        width=MODAL_WIDTH,
-        height=MODAL_HEIGHT,
+        width=width,
+        height=height,
         autosize=False,
         pos=(
-            dpg.get_viewport_width() / 2 - MODAL_WIDTH / 2,
-            dpg.get_viewport_height() / 2 - MODAL_HEIGHT / 2,
+            dpg.get_viewport_width() / 2 - width / 2,
+            dpg.get_viewport_height() / 2 - height / 2,
         ),
     )
 
     dpg.configure_item("modal_text_wrapper", pos=[8, 8])
 
     btn_width, _ = dpg.get_item_rect_size("modal_button_wrapper")
-    dpg.configure_item("modal_button_wrapper", pos=(MODAL_WIDTH / 2 - btn_width / 2 - 8, MODAL_HEIGHT - 50))
+    dpg.configure_item("modal_button_wrapper", pos=(width / 2 - btn_width / 2 - 8, height - 50))

--- a/Minify/ui/modal_shared.py
+++ b/Minify/ui/modal_shared.py
@@ -6,10 +6,12 @@ import traceback
 
 import dearpygui.dearpygui as dpg
 
+from ui import shared
+
 modal_queue = []
 
 
-def show(title, messages, buttons, width=500, height=300):
+def show(title, messages, buttons, width=shared.MODAL_WIDTH, height=shared.MODAL_HEIGHT):
     """
     Shows a unified modal popup or queues it if one is already active.
     messages: list of strings
@@ -20,7 +22,7 @@ def show(title, messages, buttons, width=500, height=300):
         show_next_from_queue()
 
 
-def show_progress(messages, width=500, height=300):
+def show_progress(messages, width=shared.MODAL_WIDTH, height=shared.MODAL_HEIGHT):
     """Shows the modal with a progress bar and status text."""
     if dpg.does_item_exist("modal_text_wrapper"):
         dpg.delete_item("modal_text_wrapper", children_only=True)
@@ -50,8 +52,8 @@ def show_next_from_queue():
     modal_data = modal_queue.pop(0)
     messages = modal_data["messages"]
     buttons = modal_data["buttons"]
-    width = modal_data.get("width", 500)
-    height = modal_data.get("height", 300)
+    width = modal_data.get("width", shared.MODAL_WIDTH)
+    height = modal_data.get("height", shared.MODAL_HEIGHT)
 
     if dpg.does_item_exist("modal_progress_wrapper"):
         dpg.configure_item("modal_progress_wrapper", show=False)
@@ -105,9 +107,9 @@ def configure(width=None, height=None):
         return
 
     if width is None:
-        width = dpg.get_item_width("modal_popup") or 500
+        width = dpg.get_item_width("modal_popup") or shared.MODAL_WIDTH
     if height is None:
-        height = dpg.get_item_height("modal_popup") or 300
+        height = dpg.get_item_height("modal_popup") or shared.MODAL_HEIGHT
 
     dpg.configure_item(
         "modal_popup",

--- a/Minify/ui/shared.py
+++ b/Minify/ui/shared.py
@@ -5,3 +5,6 @@ terminal_history = []
 tag_data_for_details_windows = []
 mod_details_image_cache = {}
 update_url = None
+
+MODAL_WIDTH = 500
+MODAL_HEIGHT = 300


### PR DESCRIPTION
This change dynamically configures the modal sizing in `Minify/ui/modal_shared.py` as requested in the issue. Constants have been removed, replacing them with parameterized arguments throughout `show`, `show_progress` and tracking dimensions in the `modal_queue` to handle queue pop sizing.

---
*PR created automatically by Jules for task [413272796065574380](https://jules.google.com/task/413272796065574380) started by @Egezenn*