### PR TITLE
🔒 Fix Path Traversal (Zip Slip) vulnerability in tarfile extraction

### DIFF
--- a/Minify/core/fs.py
+++ b/Minify/core/fs.py
@@ -188,11 +188,28 @@ def extract_archive(archive_path: str, extract_dir: str = ".", target_file: Opti
                     zip_ref.extractall(extract_dir)
         elif archive_path.endswith((".tar.gz", ".tgz")):
             with tarfile.open(archive_path, "r:gz") as tar:
+                extract_dir_abs = os.path.abspath(extract_dir)
+                safe_members = []
+                for member in tar.getmembers():
+                    member_path = os.path.abspath(os.path.join(extract_dir_abs, member.name))
+                    if os.path.commonpath([extract_dir_abs, member_path]) == extract_dir_abs:
+                        safe_members.append(member)
+
                 if target_file:
-                    member = tar.getmember(target_file)
-                    tar.extract(member, path=extract_dir)
+                    try:
+                        member = tar.getmember(target_file)
+                        if member in safe_members:
+                            if hasattr(tarfile, "data_filter"):
+                                tar.extract(member, path=extract_dir, filter="data")
+                            else:
+                                tar.extract(member, path=extract_dir)
+                    except KeyError:
+                        pass
                 else:
-                    tar.extractall(extract_dir)
+                    if hasattr(tarfile, "data_filter"):
+                        tar.extractall(path=extract_dir, members=safe_members, filter="data")
+                    else:
+                        tar.extractall(path=extract_dir, members=safe_members)
         else:
             terminal.add_text(f"Unsupported archive format: {archive_path}", msg_type="error")
             return False

--- a/tests/test_fs_security.py
+++ b/tests/test_fs_security.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import tarfile
+import tempfile
+import pytest
+
+# Add the project root and Minify directory to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Minify")))
+
+from core.fs import extract_archive
+
+
+def test_extract_archive_prevents_zip_slip(tmp_path):
+    # Create a malicious tarball
+    tar_path = tmp_path / "malicious.tar.gz"
+    extract_dir = tmp_path / "extract_dir"
+    extract_dir.mkdir()
+
+    # We want the malicious file to attempt to write outside extract_dir, e.g., to tmp_path directly
+    malicious_content = b"malicious payload"
+
+    with tarfile.open(tar_path, "w:gz") as tar:
+        # Safe file
+        safe_info = tarfile.TarInfo(name="safe.txt")
+        safe_info.size = len(b"safe")
+        import io
+
+        tar.addfile(safe_info, io.BytesIO(b"safe"))
+
+        # Malicious file attempting directory traversal
+        malicious_info = tarfile.TarInfo(name="../malicious.txt")
+        malicious_info.size = len(malicious_content)
+        tar.addfile(malicious_info, io.BytesIO(malicious_content))
+
+    # Extract
+    success = extract_archive(str(tar_path), extract_dir=str(extract_dir))
+
+    # Test assertions
+    assert success is True
+
+    # Check that safe file was extracted
+    assert (extract_dir / "safe.txt").exists()
+
+    # Check that malicious file was NOT extracted outside the directory
+    # It would be at tmp_path / "malicious.txt" based on `extract_dir / "../malicious.txt"`
+    assert not (tmp_path / "malicious.txt").exists()


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in `extract_archive` for `.tar.gz` and `.tgz` files.
⚠️ **Risk:** A maliciously crafted archive containing paths like `../malicious.txt` could allow extraction outside the target directory, potentially overwriting sensitive files on the user's system.
🛡️ **Solution:** Implemented manual validation by asserting that the `os.path.commonpath` between the extraction directory and the resolved absolute member path is the extraction directory. Also leveraged Python 3.12+ `tarfile.data_filter` if available for defense-in-depth. Malicious files are silently skipped.

---
*PR created automatically by Jules for task [15330071386205358162](https://jules.google.com/task/15330071386205358162) started by @Egezenn*