### PR TITLE
Add Tkinter background picker for Custom Backgrounds mod

### DIFF
--- a/Minify/mods/Custom Backgrounds/modcfg.json
+++ b/Minify/mods/Custom Backgrounds/modcfg.json
@@ -5,6 +5,11 @@
       "text": "Background Image Path",
       "default": "url(\"s2r://panorama/images/backgrounds/background_png.vtex\"), url(\"s2r://panorama/images/loadingscreens/international_2025_ls_3/loadingscreen.vtex\")",
       "type": "inputbox"
+    },
+    {
+      "key": "select_background",
+      "text": "Select Background",
+      "type": "button"
     }
   ]
 }

--- a/Minify/mods/Custom Backgrounds/script_utility.py
+++ b/Minify/mods/Custom Backgrounds/script_utility.py
@@ -1,0 +1,81 @@
+import os
+import shutil
+import sys
+import tkinter as tk
+from tkinter import filedialog
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+mod_name = os.path.basename(current_dir)
+minify_root = os.path.abspath(os.path.join(current_dir, os.pardir, os.pardir))
+if os.getcwd() != minify_root:
+    os.chdir(minify_root)
+
+if minify_root not in sys.path:
+    sys.path.insert(0, minify_root)
+
+from core import base, fs
+from ui import modal_shared
+
+
+def select_background():
+    root = tk.Tk()
+    root.withdraw()
+    file_path = filedialog.askopenfilename(
+        title="Select Background Image or Video",
+        filetypes=[("Media Files", "*.png *.jpg *.jpeg *.webp *.mp4 *.webm")],
+        initialdir=os.getcwd(),
+    )
+    root.destroy()
+
+    if not file_path:
+        return
+
+    actual_ext = fs.get_file_type(file_path)
+    if actual_ext == ".jpeg":
+        actual_ext = ".jpg"
+
+    allowed_exts = [".png", ".jpg", ".webp", ".mp4", ".webm"]
+
+    if not actual_ext or actual_ext not in allowed_exts:
+        modal_shared.show(
+            title="Unsupported Format",
+            messages=[f"The selected file has an unsupported format or invalid magic bytes. Detected: {actual_ext}"],
+            buttons=[{"label": "OK", "width": 100}],
+        )
+        return
+
+    dest_path = os.path.join(base.config_dir, f"background{actual_ext}")
+
+    try:
+        shutil.copy2(file_path, dest_path)
+    except Exception as e:
+        modal_shared.show(
+            title="Error", messages=[f"Failed to copy file:\n{e}"], buttons=[{"label": "OK", "width": 100}]
+        )
+        return
+
+    messages = [f"Successfully set background to {os.path.basename(dest_path)}."]
+
+    original_ext = os.path.splitext(file_path)[1].lower()
+    if original_ext == ".jpeg":
+        original_ext = ".jpg"
+
+    if original_ext != actual_ext:
+        messages.append(f"Warning: Extension mismatch. Renamed from {original_ext} to {actual_ext}.")
+
+    if actual_ext in [".jpg", ".webp"]:
+        if shutil.which("magick") is None:
+            messages.append(
+                "Warning: ImageMagick (magick) is required to convert this image to PNG during patching but is not found on your system."
+            )
+    elif actual_ext == ".mp4":
+        if shutil.which("ffmpeg") is None:
+            messages.append(
+                "Warning: FFmpeg is required to convert this video to WEBM during patching but is not found on your system."
+            )
+
+    modal_shared.show(title="Background Selected", messages=messages, buttons=[{"label": "OK", "width": 100}])
+
+
+if __name__ == "__main__":
+    select_background()

--- a/Minify/mods/Custom Backgrounds/script_utility.py
+++ b/Minify/mods/Custom Backgrounds/script_utility.py
@@ -75,7 +75,3 @@ def select_background():
             )
 
     modal_shared.show(title="Background Selected", messages=messages, buttons=[{"label": "OK", "width": 100}])
-
-
-if __name__ == "__main__":
-    select_background()


### PR DESCRIPTION
This submission adds a button to the "Custom Backgrounds" mod to allow users to select a background image/video. It utilizes `tkinter.filedialog` to present a file picker.

Once a file is picked, it verifies the file signature (magic bytes) to validate its extension. It safely moves the file to the configuration folder, handling renaming when appropriate (for instance, converting incorrectly named extensions). Furthermore, it provides the user with proper warnings through a DearPyGui modal if they lack the required tools (`magick` or `ffmpeg`) needed to convert the file during the mod patching phase.

---
*PR created automatically by Jules for task [16855873663120496872](https://jules.google.com/task/16855873663120496872) started by @Egezenn*