### PR TITLE
feat: add presets system for modcfg.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Key objects in the `modcfg.json` settings array include:
 
 - **Input Types**: `checkbox`, `combo`, `number` (`int`/`float`), `slider`, `color`, `list`, `button`.
 - Settings are rendered dynamically by `Minify/ui/settings.py` based on exactly what is defined in `modcfg.json`.
+- **Presets**: The `presets` list allows developers to provide predefined combinations of setting values.
 
 ### Mod Scripts
 

--- a/Minify/ui/settings.py
+++ b/Minify/ui/settings.py
@@ -93,6 +93,27 @@ def save(sender=None, app_data=None, user_data=None):
         config.set_mod(mod_name, mod_data)
 
 
+def apply_preset(sender, app_data, user_data):
+    mod_name = user_data["mod_name"]
+    presets = user_data["presets"]
+    combo_tag = user_data["combo_tag"]
+
+    selected_preset_name = dpg.get_value(combo_tag)
+    if not selected_preset_name:
+        return
+
+    preset = next((p for p in presets if p["name"] == selected_preset_name), None)
+    if not preset:
+        return
+
+    mod_data = config.get_mod(mod_name)
+    for k, v in preset.get("values", {}).items():
+        mod_data[k] = v
+
+    config.set_mod(mod_name, mod_data)
+    refresh()
+
+
 def handle_button_click(sender, app_data, user_data):
     mod_name = user_data["mod_name"]
     function_name = user_data["key"]
@@ -184,6 +205,35 @@ def render_menu():
                 dpg.add_text(f"{mod}:", parent="settings_content_group")
 
                 saved_mod_data = config.get_mod(mod)
+
+                presets = mod_config.get("presets", [])
+                if presets:
+                    with dpg.group(horizontal=True, parent="settings_content_group"):
+                        dpg.add_text("Presets:")
+
+                        preset_names = [p["name"] for p in presets]
+
+                        # Determine current preset
+                        current_preset = ""
+                        for p in presets:
+                            match = True
+                            for k, v in p.get("values", {}).items():
+                                if saved_mod_data.get(k) != v:
+                                    match = False
+                                    break
+                            if match:
+                                current_preset = p["name"]
+                                break
+
+                        combo_tag = f"preset_combo_{mod}"
+                        dpg.add_combo(tag=combo_tag, items=preset_names, default_value=current_preset, width=150)
+
+                        dpg.add_button(
+                            label="Apply",
+                            callback=apply_preset,
+                            user_data={"mod_name": mod, "presets": presets, "combo_tag": combo_tag},
+                        )
+
                 for opt in settings_to_render:
                     _tag = f"mod_opt_{mod}_{opt['key']}"
                     _text = opt.get("text") if opt["type"] == "checkbox" else f"{opt.get('text')}:"

--- a/docs/wiki/development/mod-structure.md
+++ b/docs/wiki/development/mod-structure.md
@@ -36,6 +36,17 @@ mods
   "order": 1, // default is 1, ordered from negative to positive to resolve any conflicts
   "visual": true, // true by default, show it in the UI as a checkbox
   
+  // presets system for custom mod settings
+  "presets": [
+    {
+      "name": "Example Preset",
+      "values": {
+        "example_inputbox": "preset_value",
+        "example_checkbox": true
+      }
+    }
+  ],
+
   // dynamically injects settings into the global Settings Menu
   "settings": [
     // key*: the internal name

--- a/tests/test_ui_settings.py
+++ b/tests/test_ui_settings.py
@@ -1,0 +1,60 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../Minify")))
+
+
+@pytest.fixture
+def mock_dpg():
+    with patch("ui.settings.dpg") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_config():
+    with patch("ui.settings.config") as mock:
+        mock.get_mod.return_value = {}
+        yield mock
+
+
+def test_apply_preset(mock_dpg, mock_config):
+    from ui.settings import apply_preset
+
+    mock_dpg.get_value.return_value = "Preset Name"
+
+    mock_config.get_mod.return_value = {"existing_key": "existing_value"}
+
+    user_data = {
+        "mod_name": "TestMod",
+        "combo_tag": "preset_combo_TestMod",
+        "presets": [{"name": "Preset Name", "values": {"setting1": "value1", "setting2": 42}}],
+    }
+
+    with patch("ui.settings.refresh") as mock_refresh:
+        apply_preset(None, None, user_data)
+
+        mock_config.set_mod.assert_called_once_with(
+            "TestMod", {"existing_key": "existing_value", "setting1": "value1", "setting2": 42}
+        )
+        mock_refresh.assert_called_once()
+
+
+def test_apply_preset_not_found(mock_dpg, mock_config):
+    from ui.settings import apply_preset
+
+    mock_dpg.get_value.return_value = "Unknown Preset"
+
+    user_data = {
+        "mod_name": "TestMod",
+        "combo_tag": "preset_combo_TestMod",
+        "presets": [{"name": "Preset Name", "values": {"setting1": "value1"}}],
+    }
+
+    with patch("ui.settings.refresh") as mock_refresh:
+        apply_preset(None, None, user_data)
+
+        mock_config.set_mod.assert_not_called()
+        mock_refresh.assert_not_called()


### PR DESCRIPTION
Adds a preset system to `modcfg.json`, allowing mod developers to define pre-configured setting values that users can select from a dropdown in the Settings UI and instantly apply.

---
*PR created automatically by Jules for task [798345704618532104](https://jules.google.com/task/798345704618532104) started by @Egezenn*