### PR TITLE
feat: Extended modcfg version checks

### DIFF
--- a/Minify/core/utils.py
+++ b/Minify/core/utils.py
@@ -37,15 +37,43 @@ def _parse_version(v: str) -> tuple:
     return tuple(parts)
 
 
-def is_version_at_least(current: str, target: str) -> bool:
+def is_version_at_least(current: str, requirements: str) -> bool:
     """
-    Compares two semantic version strings.
-    Returns True if current >= target.
+    Compares current version against a requirement string (e.g., ">=1.13,<=1.14" or "1.13").
+    If no operator is provided, defaults to ">=".
     """
     try:
-        if current is None or target is None:
+        if current is None or requirements is None:
             return False
-        return _parse_version(current) >= _parse_version(target)
+
+        current_v = _parse_version(current)
+        reqs = [r.strip() for r in requirements.split(",") if r.strip()]
+
+        for req in reqs:
+            match = re.match(r"^(>=|<=|>|<|==|=)?\s*(.+)$", req)
+            if not match:
+                return False
+
+            op = match.group(1) or ">="
+            target_v = _parse_version(match.group(2))
+
+            if op == ">=":
+                if not (current_v >= target_v):
+                    return False
+            elif op == "<=":
+                if not (current_v <= target_v):
+                    return False
+            elif op == ">":
+                if not (current_v > target_v):
+                    return False
+            elif op == "<":
+                if not (current_v < target_v):
+                    return False
+            elif op in ("==", "="):
+                if not (current_v == target_v):
+                    return False
+
+        return True
     except (ValueError, AttributeError, IndexError, TypeError):
         return False
 

--- a/Minify/ui/checkboxes.py
+++ b/Minify/ui/checkboxes.py
@@ -95,13 +95,25 @@ def create():
 
     for mod in constants.visually_available_mods:
         mod_path = os.path.join(base.mods_dir, mod)
+        unsupported_version = False
         if is_vpk := mod.endswith(".vpk"):
             always_val = False
         else:
             mod_cfg_path = os.path.join(mod_path, "modcfg.json")
-            always_val = config.read_json_file(mod_cfg_path).get("always", False)
+            cfg = config.read_json_file(mod_cfg_path)
+            always_val = cfg.get("always", False)
+            if version_req := cfg.get("version"):
+                if not utils.is_version_at_least(base.VERSION, version_req):
+                    unsupported_version = True
 
-        if always_val:
+        if unsupported_version:
+            enable_ticking = False
+            value = False
+            if checkboxes_state.get(mod, False):
+                checkboxes_state[mod] = False
+                save()
+            terminal.add_text(f"Disabled {mod} (Requires version {version_req})", msg_type="warning")
+        elif always_val:
             enable_ticking = False
             value = True
         else:

--- a/docs/wiki/development/mod-structure.md
+++ b/docs/wiki/development/mod-structure.md
@@ -35,6 +35,7 @@ mods
   "dependencies": ["<mod>"], // None by default, add a mod dependency's name here 
   "order": 1, // default is 1, ordered from negative to positive to resolve any conflicts
   "visual": true, // true by default, show it in the UI as a checkbox
+  "version": ">=1.13,<=1.14", // optional, enforces a Minify version requirement (supports operators: >=, <=, >, <, ==)
   
   // dynamically injects settings into the global Settings Menu
   "settings": [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,35 @@ def test_is_version_at_least_standard():
     assert is_version_at_least("1.13.0", "1.13") is True  # 1.13.0 vs 1.13
 
 
+def test_is_version_at_least_operators():
+    # >= operator
+    assert is_version_at_least("1.13.2", ">=1.13.1") is True
+    assert is_version_at_least("1.13.1", ">=1.13.2") is False
+
+    # <= operator
+    assert is_version_at_least("1.13.1", "<=1.13.2") is True
+    assert is_version_at_least("1.13.2", "<=1.13.1") is False
+
+    # > operator
+    assert is_version_at_least("1.13.2", ">1.13.1") is True
+    assert is_version_at_least("1.13.2", ">1.13.2") is False
+
+    # < operator
+    assert is_version_at_least("1.13.1", "<1.13.2") is True
+    assert is_version_at_least("1.13.1", "<1.13.1") is False
+
+    # == and = operator
+    assert is_version_at_least("1.13.2", "==1.13.2") is True
+    assert is_version_at_least("1.13.2", "=1.13.2") is True
+    assert is_version_at_least("1.13.1", "==1.13.2") is False
+
+    # multiple operators
+    assert is_version_at_least("1.13.5", ">=1.13.0, <=1.14.0") is True
+    assert is_version_at_least("1.15.0", ">=1.13.0, <=1.14.0") is False
+    assert is_version_at_least("1.12.0", ">=1.13.0, <=1.14.0") is False
+    assert is_version_at_least("1.13.2", ">1.13.0,<1.14.0") is True
+
+
 def test_is_version_at_least_rc():
     # Final is greater than rc
     assert is_version_at_least("1.13.2", "1.13.2rc2") is True


### PR DESCRIPTION
Implements extended version requirement checks for `modcfg.json`.

Mods can now declare multi-conditional requirements like `"version": ">=1.13,<=1.14"`. If the current Minify version falls outside this range, the mod will be disabled gracefully, preventing UI toggling, and outputting a visible yellow warning string to the terminal.

---
*PR created automatically by Jules for task [7391378750072468801](https://jules.google.com/task/7391378750072468801) started by @Egezenn*