### PR TITLE
feat: add search filters to native mod list

### DIFF
--- a/Minify/bin/localization.json
+++ b/Minify/bin/localization.json
@@ -1148,7 +1148,32 @@
     "ZH-TW": "壓縮過程中遇到錯誤.請查看 Minify/logs/warnings.txt 檔案以了解詳情."
   },
   "mod_search_hint_var": {
-    "EN": "Search by mod name or manifest key:value..."
+    "EN": "Search by mod name or manifest key:value...",
+    "BG": "Търсене по име на мод или key:value в манифеста...",
+    "CS": "Hledat podle názvu modu nebo key:value v manifestu...",
+    "DA": "Søg efter modnavn eller key:value i manifestet...",
+    "DE": "Nach Mod-Namen oder key:value im Manifest suchen...",
+    "EL": "Αναζήτηση βάσει ονόματος mod ή key:value στο manifest...",
+    "ES": "Buscar por nombre del mod o key:value del manifiesto...",
+    "FI": "Hae modin nimellä tai manifestin key:value-parilla...",
+    "FR": "Rechercher par nom de mod ou key:value du manifeste...",
+    "HU": "Keresés modnév vagy manifest key:value alapján...",
+    "IT": "Cerca per nome della mod o key:value del manifest...",
+    "JA": "Mod名またはマニフェストのkey:valueで検索...",
+    "KO": "모드 이름 또는 매니페스트 key:value로 검색...",
+    "NL": "Zoeken op modnaam of key:value in het manifest...",
+    "NO": "Søk etter modnavn eller key:value i manifestet...",
+    "PL": "Szukaj według nazwy moda lub key:value w manifeście...",
+    "PT": "Pesquisar por nome do mod ou key:value do manifesto...",
+    "RO": "Caută după numele modului sau key:value din manifest...",
+    "RU": "Поиск по названию мода или key:value из манифеста...",
+    "SV": "Sök efter modnamn eller key:value i manifestet...",
+    "TH": "ค้นหาด้วยชื่อม็อดหรือ key:value ในไฟล์ manifest...",
+    "TR": "Mod adına veya manifest key:value değerine göre ara...",
+    "UK": "Пошук за назвою мода або key:value з маніфесту...",
+    "VI": "Tìm theo tên mod hoặc key:value trong manifest...",
+    "ZH-CN": "按模组名称或 manifest 的 key:value 搜索...",
+    "ZH-TW": "依模組名稱或 manifest 的 key:value 搜尋..."
   },
   "mod_selection_window_var": {
     "EN": "Mod Selection Menu",

--- a/Minify/bin/localization.json
+++ b/Minify/bin/localization.json
@@ -1147,6 +1147,9 @@
     "ZH-CN": "压缩过程中遇到错误.请查看 Minify/logs/warnings.txt 文件了解详情.",
     "ZH-TW": "壓縮過程中遇到錯誤.請查看 Minify/logs/warnings.txt 檔案以了解詳情."
   },
+  "mod_search_hint_var": {
+    "EN": "Search by mod name or manifest key:value..."
+  },
   "mod_selection_window_var": {
     "EN": "Mod Selection Menu",
     "BG": "Меню за избор на мод",

--- a/Minify/ui/checkboxes.py
+++ b/Minify/ui/checkboxes.py
@@ -13,6 +13,176 @@ from ui import details, localization, settings, shared, theme
 
 checkboxes = []
 checkboxes_state = {}
+mod_filter_query = ""
+mod_filter_metadata = {}
+mod_filter_item_tags = {}
+
+
+def _stringify_filter_values(value):
+    if isinstance(value, dict):
+        for nested_key, nested_value in value.items():
+            yield str(nested_key)
+            yield from _stringify_filter_values(nested_value)
+    elif isinstance(value, (list, tuple, set)):
+        for nested_value in value:
+            yield from _stringify_filter_values(nested_value)
+    elif value is None:
+        yield "null"
+    elif isinstance(value, bool):
+        yield str(value).lower()
+    else:
+        yield str(value)
+
+
+def _iter_manifest_path_values(value, path):
+    if not path:
+        yield value
+        return
+
+    if isinstance(value, dict):
+        target_key = path[0]
+        for current_key, current_value in value.items():
+            if str(current_key).casefold() == target_key:
+                yield from _iter_manifest_path_values(current_value, path[1:])
+    elif isinstance(value, (list, tuple, set)):
+        for nested_value in value:
+            yield from _iter_manifest_path_values(nested_value, path)
+
+
+def _iter_manifest_values_for_key(value, key):
+    if "." in key:
+        path = [part.casefold() for part in key.split(".")]
+        if any(not part for part in path):
+            return
+        for matched_value in _iter_manifest_path_values(value, path):
+            yield from _stringify_filter_values(matched_value)
+        return
+
+    target_key = key.casefold()
+    if isinstance(value, dict):
+        direct_values = [
+            current_value for current_key, current_value in value.items() if str(current_key).casefold() == target_key
+        ]
+        if direct_values:
+            for direct_value in direct_values:
+                yield from _stringify_filter_values(direct_value)
+            return
+
+        for current_value in value.values():
+            yield from _iter_manifest_values_for_key(current_value, key)
+    elif isinstance(value, (list, tuple, set)):
+        for nested_value in value:
+            yield from _iter_manifest_values_for_key(nested_value, key)
+
+
+def _tokenize_mod_filter(query):
+    tokens = []
+    current = []
+    quote = None
+    had_quote = False
+    index = 0
+
+    while index < len(query):
+        char = query[index]
+        if quote:
+            if char == "\\" and index + 1 < len(query) and query[index + 1] == quote:
+                current.append(quote)
+                index += 1
+            elif char == quote:
+                quote = None
+                had_quote = True
+            else:
+                current.append(char)
+        elif char in ('"', "'") and (not current or current[-1] == ":"):
+            quote = char
+            had_quote = True
+        elif char.isspace():
+            if current or had_quote:
+                tokens.append(("".join(current), had_quote))
+                current = []
+                had_quote = False
+        else:
+            current.append(char)
+        index += 1
+
+    if current or had_quote:
+        tokens.append(("".join(current), had_quote))
+
+    return tokens
+
+
+def _is_filter_start(token, has_open_filter):
+    key, separator, value = token.partition(":")
+    key_parts = key.strip().split(".")
+    valid_key = separator and all(
+        part and all(char.isalnum() or char in ("_", "-") for char in part) for part in key_parts
+    )
+    if not valid_key:
+        return False
+
+    if has_open_filter and (value.startswith("//") or (len(key) == 1 and value.startswith(("\\", "/")))):
+        return False
+
+    return True
+
+
+def parse_mod_filter(query):
+    query = str(query or "").strip()
+    if not query:
+        return []
+
+    parsed_tokens = []
+    open_filter_index = None
+
+    for token, had_quote in _tokenize_mod_filter(query):
+        if not token:
+            continue
+
+        if _is_filter_start(token, open_filter_index is not None):
+            parsed_tokens.append(token)
+            open_filter_index = None if had_quote else len(parsed_tokens) - 1
+        elif open_filter_index is not None:
+            parsed_tokens[open_filter_index] += f" {token}"
+        else:
+            parsed_tokens.append(token)
+
+    return parsed_tokens
+
+
+def mod_matches_filter(mod_name, manifest, query):
+    mod_name = str(mod_name).casefold()
+    manifest = manifest if isinstance(manifest, dict) else {}
+
+    for token in parse_mod_filter(query):
+        key, separator, expected = token.partition(":")
+        if separator:
+            key = key.strip().casefold()
+            expected = expected.strip().casefold()
+            if not key or not expected:
+                return False
+
+            if key == "mod":
+                values = (mod_name,)
+            else:
+                values = _iter_manifest_values_for_key(manifest, key)
+
+            if not any(expected in value.casefold() for value in values):
+                return False
+        elif token.casefold() not in mod_name:
+            return False
+
+    return True
+
+
+def filter_mods(sender=None, app_data=None, user_data=None):
+    global mod_filter_query
+    if app_data is not None:
+        mod_filter_query = str(app_data)
+
+    for mod, manifest in mod_filter_metadata.items():
+        group_tag = mod_filter_item_tags.get(mod)
+        if group_tag and dpg.does_item_exist(group_tag):
+            dpg.configure_item(group_tag, show=mod_matches_filter(mod, manifest, mod_filter_query))
 
 
 def load():
@@ -73,6 +243,18 @@ def create():
     shared.mod_details_image_cache.clear()
 
     checkboxes.clear()
+    mod_filter_metadata.clear()
+    mod_filter_item_tags.clear()
+
+    dpg.add_input_text(
+        parent="mod_menu",
+        tag="mod_search_input",
+        hint="Search by mod name or manifest key:value...",
+        default_value=mod_filter_query,
+        width=-1,
+        callback=filter_mods,
+    )
+    dpg.add_separator(parent="mod_menu")
 
     mod_details_cache = {}
 
@@ -109,6 +291,7 @@ def create():
         unsupported_version = False
         if is_vpk := mod.endswith(".vpk"):
             always_val = False
+            cfg = {}
         else:
             cfg = manifest_utils.get_mod(mod_path)
             always_val = cfg.get("always", False)
@@ -135,9 +318,12 @@ def create():
             enable_ticking = True
             value = checkboxes_state.get(mod, False)
 
-        dpg.add_group(parent="mod_menu", tag=f"{mod}_group_tag", horizontal=True, width=base.main_window_width)
+        group_tag = f"{mod}_group_tag"
+        mod_filter_metadata[mod] = cfg
+        mod_filter_item_tags[mod] = group_tag
+        dpg.add_group(parent="mod_menu", tag=group_tag, horizontal=True, width=base.main_window_width)
         dpg.add_checkbox(
-            parent=f"{mod}_group_tag",
+            parent=group_tag,
             label=mod[:-4] if is_vpk else mod,
             tag=mod,
             callback=setup_state,
@@ -195,6 +381,7 @@ def create():
         checkboxes.append(mod)
 
     conditions.disable_workshop_mods()
+    filter_mods(app_data=mod_filter_query)
 
 
 def get_value(mod):

--- a/Minify/ui/checkboxes.py
+++ b/Minify/ui/checkboxes.py
@@ -120,6 +120,8 @@ def _is_filter_start(token, has_open_filter):
     if not valid_key:
         return False
 
+    # Keep URL schemes and Windows drive paths attached to the open filter value
+    # instead of treating them as a new key:value pair.
     if has_open_filter and (value.startswith("//") or (len(key) == 1 and value.startswith(("\\", "/")))):
         return False
 
@@ -179,10 +181,10 @@ def filter_mods(sender=None, app_data=None, user_data=None):
     if app_data is not None:
         mod_filter_query = str(app_data)
 
-    for mod, manifest in mod_filter_metadata.items():
+    for mod, (display_name, manifest) in mod_filter_metadata.items():
         group_tag = mod_filter_item_tags.get(mod)
         if group_tag and dpg.does_item_exist(group_tag):
-            dpg.configure_item(group_tag, show=mod_matches_filter(mod, manifest, mod_filter_query))
+            dpg.configure_item(group_tag, show=mod_matches_filter(display_name, manifest, mod_filter_query))
 
 
 def load():
@@ -249,7 +251,7 @@ def create():
     dpg.add_input_text(
         parent="mod_menu",
         tag="mod_search_input",
-        hint="Search by mod name or manifest key:value...",
+        hint=localization.mod_search_hint_var,
         default_value=mod_filter_query,
         width=-1,
         callback=filter_mods,
@@ -319,12 +321,13 @@ def create():
             value = checkboxes_state.get(mod, False)
 
         group_tag = f"{mod}_group_tag"
-        mod_filter_metadata[mod] = cfg
+        display_name = mod[:-4] if is_vpk else mod
+        mod_filter_metadata[mod] = (display_name, cfg)
         mod_filter_item_tags[mod] = group_tag
         dpg.add_group(parent="mod_menu", tag=group_tag, horizontal=True, width=base.main_window_width)
         dpg.add_checkbox(
             parent=group_tag,
-            label=mod[:-4] if is_vpk else mod,
+            label=display_name,
             tag=mod,
             callback=setup_state,
             default_value=value,

--- a/Minify/ui/localization.py
+++ b/Minify/ui/localization.py
@@ -12,6 +12,7 @@ locale = ""
 localization_dict = {}
 localizations = []
 details_label = ""
+mod_search_hint_var = ""
 mod_selection_window_var = ""
 
 
@@ -42,7 +43,7 @@ def get_available():
 
 
 def change(sender=None, app_data=None, user_data=None, init=False):
-    global locale, details_label, mod_selection_window_var
+    global locale, details_label, mod_search_hint_var, mod_selection_window_var
 
     with utils.open_utf8(base.localization_file_dir) as localization_file:
         localization_data = jsonc.load(localization_file)
@@ -100,12 +101,17 @@ def change(sender=None, app_data=None, user_data=None, init=False):
     details_label = localization_data.get("details_button_label_var", {}).get(
         locale, localization_data["details_button_label_var"]["EN"]
     )
+    mod_search_hint_var = localization_data.get("mod_search_hint_var", {}).get(
+        locale, localization_data["mod_search_hint_var"]["EN"]
+    )
     mod_selection_window_var = localization_data.get("mod_selection_window_var", {}).get(
         locale, localization_data["mod_selection_window_var"]["EN"]
     )
 
     if dpg.does_item_exist("mod_menu"):
         dpg.configure_item("mod_menu", label=mod_selection_window_var)
+        if dpg.does_item_exist("mod_search_input"):
+            dpg.configure_item("mod_search_input", hint=mod_search_hint_var)
         for child_group in dpg.get_item_children("mod_menu", 1):
             for item in dpg.get_item_children(child_group, 1):
                 if dpg.get_item_alias(item).endswith("_button_show_details_tag"):

--- a/tests/test_checkboxes.py
+++ b/tests/test_checkboxes.py
@@ -1,30 +1,43 @@
+import pytest
+
 from ui.checkboxes import mod_matches_filter, parse_mod_filter
 
 
-def test_parse_mod_filter_supports_quoted_values():
-    assert parse_mod_filter('dependencies:"Dark Terrain" order:2') == ["dependencies:Dark Terrain", "order:2"]
-
-
-def test_parse_mod_filter_supports_unquoted_multiword_values():
-    assert parse_mod_filter("dark dependencies:Remove Foilage order:2") == [
-        "dark",
-        "dependencies:Remove Foilage",
-        "order:2",
-    ]
-    assert parse_mod_filter("order: 2") == ["order: 2"]
-
-
-def test_parse_mod_filter_preserves_backslashes():
-    assert parse_mod_filter(r"default:C:\Mods\Terrain") == [r"default:C:\Mods\Terrain"]
-    assert parse_mod_filter("author:O'Connor") == ["author:O'Connor"]
-    assert parse_mod_filter('default:url("s2r://image"), url("s2r://fallback")') == [
-        'default:url("s2r://image"), url("s2r://fallback")'
-    ]
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ('dependencies:"Dark Terrain" order:2', ["dependencies:Dark Terrain", "order:2"]),
+        (
+            "dark dependencies:Remove Foilage order:2",
+            ["dark", "dependencies:Remove Foilage", "order:2"],
+        ),
+        ("order: 2", ["order: 2"]),
+        (r"default:C:\Mods\Terrain", [r"default:C:\Mods\Terrain"]),
+        ("author:O'Connor", ["author:O'Connor"]),
+        (
+            'default:url("s2r://image"), url("s2r://fallback")',
+            ['default:url("s2r://image"), url("s2r://fallback")'],
+        ),
+    ],
+)
+def test_parse_mod_filter_returns_expected_tokens(query, expected):
+    assert parse_mod_filter(query) == expected
 
 
 def test_mod_matches_filter_by_name_with_and_semantics():
     assert mod_matches_filter("Dark Terrain", {}, "dark terrain")
     assert not mod_matches_filter("Dark Terrain", {}, "dark weather")
+
+
+@pytest.mark.parametrize("query", ["", "   ", None])
+def test_mod_matches_filter_empty_query_matches_every_mod(query):
+    assert mod_matches_filter("Dark Terrain", {"order": 2}, query)
+
+
+@pytest.mark.parametrize("manifest", [None, [], "not-a-dict", 5])
+def test_mod_matches_filter_non_dict_manifest_falls_back_to_name_only(manifest):
+    assert mod_matches_filter("Dark Terrain", manifest, "dark")
+    assert not mod_matches_filter("Dark Terrain", manifest, "order:2")
 
 
 def test_mod_matches_filter_by_manifest_keys_and_nested_values():

--- a/tests/test_checkboxes.py
+++ b/tests/test_checkboxes.py
@@ -1,0 +1,81 @@
+from ui.checkboxes import mod_matches_filter, parse_mod_filter
+
+
+def test_parse_mod_filter_supports_quoted_values():
+    assert parse_mod_filter('dependencies:"Dark Terrain" order:2') == ["dependencies:Dark Terrain", "order:2"]
+
+
+def test_parse_mod_filter_supports_unquoted_multiword_values():
+    assert parse_mod_filter("dark dependencies:Remove Foilage order:2") == [
+        "dark",
+        "dependencies:Remove Foilage",
+        "order:2",
+    ]
+    assert parse_mod_filter("order: 2") == ["order: 2"]
+
+
+def test_parse_mod_filter_preserves_backslashes():
+    assert parse_mod_filter(r"default:C:\Mods\Terrain") == [r"default:C:\Mods\Terrain"]
+    assert parse_mod_filter("author:O'Connor") == ["author:O'Connor"]
+    assert parse_mod_filter('default:url("s2r://image"), url("s2r://fallback")') == [
+        'default:url("s2r://image"), url("s2r://fallback")'
+    ]
+
+
+def test_mod_matches_filter_by_name_with_and_semantics():
+    assert mod_matches_filter("Dark Terrain", {}, "dark terrain")
+    assert not mod_matches_filter("Dark Terrain", {}, "dark weather")
+
+
+def test_mod_matches_filter_by_manifest_keys_and_nested_values():
+    manifest = {
+        "order": 2,
+        "always": False,
+        "browser": {"name": "d2pfx", "category": "terrain"},
+        "dependencies": ["Weather FX"],
+    }
+
+    assert mod_matches_filter("Dark Terrain", manifest, "order:2 browser:d2pfx category:terrain")
+    assert mod_matches_filter("Dark Terrain", manifest, 'dependencies:"weather fx"')
+    assert mod_matches_filter("Dark Terrain", manifest, "dependencies:weather fx")
+    assert not mod_matches_filter("Dark Terrain", manifest, "order:3")
+    assert not mod_matches_filter("Dark Terrain", manifest, "missing:value")
+
+
+def test_mod_matches_filter_handles_boolean_manifest_values():
+    assert mod_matches_filter("Always Visible", {"always": True}, "always:true")
+    assert not mod_matches_filter("Always Visible", {"always": True}, "always:false")
+
+
+def test_mod_matches_filter_supports_dotted_paths_and_prefers_top_level_keys():
+    manifest = {
+        "version": ">=1.14",
+        "browser": {"name": "terrain-remix", "version": "2.0", "category": "terrains"},
+    }
+
+    assert mod_matches_filter("D2PFX TERRAINS - Terrain Remix", manifest, "version:1.14")
+    assert not mod_matches_filter("D2PFX TERRAINS - Terrain Remix", manifest, "version:2.0")
+    assert mod_matches_filter("D2PFX TERRAINS - Terrain Remix", manifest, "browser.version:2.0")
+    assert mod_matches_filter("D2PFX TERRAINS - Terrain Remix", manifest, "name:terrain-remix")
+    assert mod_matches_filter("D2PFX TERRAINS - Terrain Remix", manifest, "mod:d2pfx")
+
+
+def test_mod_matches_filter_searches_map_keys_and_json_null():
+    manifest = {
+        "browser": {
+            "author": None,
+            "tags": {"anime": True, "adult": False},
+        }
+    }
+
+    assert mod_matches_filter("Browser Mod", manifest, "tags:anime")
+    assert mod_matches_filter("Browser Mod", manifest, "browser.tags.anime:true")
+    assert mod_matches_filter("Browser Mod", manifest, "author:null")
+    assert not mod_matches_filter("Browser Mod", manifest, "author:none")
+
+
+def test_mod_matches_filter_supports_paths_through_setting_lists():
+    manifest = {"settings": [{"key": "fetch_grids", "type": "button"}]}
+
+    assert mod_matches_filter("Custom Hero Grids", manifest, "settings.type:button")
+    assert mod_matches_filter("Custom Hero Grids", manifest, "settings.key:fetch_grids")


### PR DESCRIPTION
## Summary

- add a search field to the native mod list
- support case-insensitive mod-name and `key:value` manifest filters
- support multi-word values, nested paths, lists, maps, booleans, and JSON `null`
- preserve the active query when the mod list is refreshed
- add focused parser and matching tests

## Why

The native mod list previously rendered every available mod without any way to search or filter it. This implements the roadmap request while keeping checkbox state and Details behavior unchanged.

Closes #140.

## Validation

- `uv run ruff format --check Minify/ui/checkboxes.py tests/test_checkboxes.py`
- `uv run ruff check Minify/ui/checkboxes.py tests/test_checkboxes.py`
- `uv run pytest tests/test_checkboxes.py tests/test_ui_settings.py -q` — 11 passed
- full local precommit on Windows — 126 passed; `test_patch_accepts_config_and_mods_paths` remains Windows-specific because `/tmp/...` is normalized to `C:\tmp\...` and is unrelated to this diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mod search and filtering to the mod menu.
  * Search supports free-text terms, quoted or multiword values, and case-insensitive `key:value` filters.
  * Filters can match mod names and manifest metadata, including nested fields, lists, booleans, and empty values.
  * Added localized search guidance for supported languages.

* **Tests**
  * Added coverage for advanced search syntax and metadata-matching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->